### PR TITLE
Replace dependency on JRE8 with JDK8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ subprojects {
 
   dependencyManagement {
     dependencies {
-      dependency "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+      dependency "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
       dependency "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version" // managing version up
       dependency "com.google.inject:guice:$guice_version"
       dependency "com.google.inject.extensions:guice-multibindings:$guice_version"


### PR DESCRIPTION
Including the JRE package results in Gradle build warnings about it being deprecated.
See http://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages.