### PR TITLE
Add delegating builders to binder skipSources

### DIFF
--- a/kotlin-guice/src/main/kotlin/com/authzee/kotlinguice4/KotlinModule.kt
+++ b/kotlin-guice/src/main/kotlin/com/authzee/kotlinguice4/KotlinModule.kt
@@ -18,6 +18,10 @@
 package com.authzee.kotlinguice4
 
 import com.authzee.kotlinguice4.binder.KotlinAnnotatedBindingBuilder
+import com.authzee.kotlinguice4.binder.KotlinAnnotatedElementBuilder
+import com.authzee.kotlinguice4.binder.KotlinLinkedBindingBuilder
+import com.authzee.kotlinguice4.binder.KotlinScopedBindingBuilder
+import com.authzee.kotlinguice4.internal.KotlinBindingBuilder
 import com.google.inject.AbstractModule
 import com.google.inject.MembersInjector
 import com.google.inject.Provider
@@ -55,7 +59,14 @@ import com.google.inject.Scope
 abstract class KotlinModule : AbstractModule() {
     /** Gets direct access to the underlying [KotlinBinder]. */
     protected val kotlinBinder: KotlinBinder by lazy {
-        KotlinBinder(binder().skipSources(KotlinBinder::class.java))
+        KotlinBinder(binder().skipSources(
+            KotlinAnnotatedBindingBuilder::class.java,
+            KotlinAnnotatedElementBuilder::class.java,
+            KotlinBinder::class.java,
+            KotlinBindingBuilder::class.java,
+            KotlinLinkedBindingBuilder::class.java,
+            KotlinScopedBindingBuilder::class.java
+        ))
     }
 
     /** @see KotlinBinder.bindScope */

--- a/kotlin-guice/src/main/kotlin/com/authzee/kotlinguice4/KotlinPrivateModule.kt
+++ b/kotlin-guice/src/main/kotlin/com/authzee/kotlinguice4/KotlinPrivateModule.kt
@@ -19,6 +19,9 @@ package com.authzee.kotlinguice4
 
 import com.authzee.kotlinguice4.binder.KotlinAnnotatedBindingBuilder
 import com.authzee.kotlinguice4.binder.KotlinAnnotatedElementBuilder
+import com.authzee.kotlinguice4.binder.KotlinLinkedBindingBuilder
+import com.authzee.kotlinguice4.binder.KotlinScopedBindingBuilder
+import com.authzee.kotlinguice4.internal.KotlinBindingBuilder
 import com.google.inject.MembersInjector
 import com.google.inject.PrivateModule
 import com.google.inject.Provider
@@ -60,7 +63,14 @@ import com.google.inject.Scope
 abstract class KotlinPrivateModule : PrivateModule() {
     /** Gets direct access to the underlying [KotlinPrivateBinder]. */
     protected val kotlinBinder: KotlinPrivateBinder by lazy {
-        KotlinPrivateBinder(binder().skipSources(KotlinPrivateModule::class.java))
+        KotlinPrivateBinder(binder().skipSources(
+            KotlinAnnotatedBindingBuilder::class.java,
+            KotlinAnnotatedElementBuilder::class.java,
+            KotlinBinder::class.java,
+            KotlinBindingBuilder::class.java,
+            KotlinLinkedBindingBuilder::class.java,
+            KotlinScopedBindingBuilder::class.java
+        ))
     }
 
     /** Makes the binding for [T] available to enclosing modules and the injector. */

--- a/kotlin-guice/src/test/kotlin/com/authzee/kotlinguice4/KotlinModuleSpec.kt
+++ b/kotlin-guice/src/test/kotlin/com/authzee/kotlinguice4/KotlinModuleSpec.kt
@@ -25,6 +25,7 @@ import com.google.inject.Key
 import com.google.inject.spi.ElementSource
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldThrow
@@ -181,6 +182,23 @@ object KotlinModuleSpec : Spek({
 
                 val callable: Callable<*> = injector.getInstance(key<Callable<*>>())
                 callable shouldBeInstanceOf ACallable::class.java
+            }
+
+            describe("when binding to a null instance") {
+                it("throws a CreationException with message that skips internal sources") {
+                    val outerModule = object : KotlinModule() {
+                        override fun configure() {
+                            bind<String>().toInstance(null)
+                        }
+                    }
+
+                    val createInjector = {
+                        Guice.createInjector(outerModule)
+                    }
+
+                    val exception = (createInjector shouldThrow CreationException::class).exception
+                    exception.message!! shouldContain outerModule::class.java.name
+                }
             }
         }
 

--- a/kotlin-guice/src/test/kotlin/com/authzee/kotlinguice4/KotlinPrivateModuleSpec.kt
+++ b/kotlin-guice/src/test/kotlin/com/authzee/kotlinguice4/KotlinPrivateModuleSpec.kt
@@ -24,6 +24,7 @@ import com.google.inject.Guice
 import com.google.inject.spi.ElementSource
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldThrow
@@ -278,6 +279,23 @@ class KotlinPrivateModuleSpec : Spek({
 
                 val callable: Callable<*> = injector.getInstance(key<Callable<*>>())
                 callable shouldBeInstanceOf ACallable::class.java
+            }
+
+            describe("when binding to a null instance") {
+                it("throws a CreationException with message that skips internal sources") {
+                    val outerModule = object : KotlinPrivateModule() {
+                        override fun configure() {
+                            bind<String>().toInstance(null)
+                        }
+                    }
+
+                    val createInjector = {
+                        Guice.createInjector(outerModule)
+                    }
+
+                    val exception = (createInjector shouldThrow CreationException::class).exception
+                    exception.message!! shouldContain outerModule::class.java.name
+                }
             }
         }
 


### PR DESCRIPTION
By skipping the delegating builders, errors should provide better error messages.