### PR TITLE
fix issue with binder caching in kotlin module

### DIFF
--- a/kotlin-guice/src/main/kotlin/dev/misfitlabs/kotlinguice4/KotlinModule.kt
+++ b/kotlin-guice/src/main/kotlin/dev/misfitlabs/kotlinguice4/KotlinModule.kt
@@ -18,6 +18,7 @@
 package dev.misfitlabs.kotlinguice4
 
 import com.google.inject.AbstractModule
+import com.google.inject.Binder
 import com.google.inject.MembersInjector
 import com.google.inject.Provider
 import com.google.inject.Scope
@@ -26,6 +27,7 @@ import dev.misfitlabs.kotlinguice4.binder.KotlinAnnotatedElementBuilder
 import dev.misfitlabs.kotlinguice4.binder.KotlinLinkedBindingBuilder
 import dev.misfitlabs.kotlinguice4.binder.KotlinScopedBindingBuilder
 import dev.misfitlabs.kotlinguice4.internal.KotlinBindingBuilder
+import kotlin.reflect.KProperty
 
 /**
  * An extension of [AbstractModule] that enhances the binding DSL to allow binding using reified
@@ -57,16 +59,32 @@ import dev.misfitlabs.kotlinguice4.internal.KotlinBindingBuilder
  * @since 1.0
  */
 abstract class KotlinModule : AbstractModule() {
-    private val classesToSkip = arrayOf(KotlinAnnotatedBindingBuilder::class.java,
-            KotlinAnnotatedElementBuilder::class.java,
-            KotlinBinder::class.java,
-            KotlinBindingBuilder::class.java,
-            KotlinLinkedBindingBuilder::class.java,
-            KotlinScopedBindingBuilder::class.java)
+    private class KotlinLazyBinder(private val binderSource: Provider<Binder>) {
+        private val classesToSkip = arrayOf(
+                KotlinAnnotatedBindingBuilder::class.java,
+                KotlinAnnotatedElementBuilder::class.java,
+                KotlinBinder::class.java,
+                KotlinBindingBuilder::class.java,
+                KotlinLinkedBindingBuilder::class.java,
+                KotlinScopedBindingBuilder::class.java
+        )
+
+        var lazyBinder = lazyInit()
+        var currentBinder: Binder? = null
+
+        operator fun getValue(thisRef: Any?, property: KProperty<*>): KotlinBinder {
+            if (currentBinder != binderSource.get()) {
+                currentBinder = binderSource.get()
+                lazyBinder = lazyInit()
+            }
+            return lazyBinder.value
+        }
+
+        private fun lazyInit() = lazy { KotlinBinder(binderSource.get().skipSources(*classesToSkip)) }
+    }
 
     /** Gets direct access to the underlying [KotlinBinder]. */
-    protected val kotlinBinder: KotlinBinder
-        get() = KotlinBinder(binder().skipSources(*classesToSkip))
+    protected val kotlinBinder: KotlinBinder by KotlinLazyBinder(Provider { this.binder() })
 
     /** @see KotlinBinder.bindScope */
     protected inline fun <reified TAnn : Annotation> bindScope(scope: Scope) {

--- a/kotlin-guice/src/main/kotlin/dev/misfitlabs/kotlinguice4/KotlinModule.kt
+++ b/kotlin-guice/src/main/kotlin/dev/misfitlabs/kotlinguice4/KotlinModule.kt
@@ -57,17 +57,16 @@ import dev.misfitlabs.kotlinguice4.internal.KotlinBindingBuilder
  * @since 1.0
  */
 abstract class KotlinModule : AbstractModule() {
-    /** Gets direct access to the underlying [KotlinBinder]. */
-    protected val kotlinBinder: KotlinBinder by lazy {
-        KotlinBinder(binder().skipSources(
-            KotlinAnnotatedBindingBuilder::class.java,
+    private val classesToSkip = arrayOf(KotlinAnnotatedBindingBuilder::class.java,
             KotlinAnnotatedElementBuilder::class.java,
             KotlinBinder::class.java,
             KotlinBindingBuilder::class.java,
             KotlinLinkedBindingBuilder::class.java,
-            KotlinScopedBindingBuilder::class.java
-        ))
-    }
+            KotlinScopedBindingBuilder::class.java)
+
+    /** Gets direct access to the underlying [KotlinBinder]. */
+    protected val kotlinBinder: KotlinBinder
+        get() = KotlinBinder(binder().skipSources(*classesToSkip))
 
     /** @see KotlinBinder.bindScope */
     protected inline fun <reified TAnn : Annotation> bindScope(scope: Scope) {


### PR DESCRIPTION
unfortunately `protected val kotlinBinder: KotlinBinder by lazy {` does not always work fine and can cache wrong binder. As result guice can't find some dependencies even these are declared.

please take a look test that confirm this issue here https://github.com/ashirman/kotlin_guice_bind_error_test 

it is fairly easy to cache "wrong" binder for Kotlin module. Eg
` val elements = Elements.getElements(modules)`. it uses `RecordingBinder` which is cached by Kotlin module after first usage.

the only solution that I was able to find saving backward compatibility is to delete `by lazy {` for `kotlinBinder: KotlinBinder`.