### PR TITLE
Upgrade Guice to 5.0.1 and Kotlin to 1.4.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Change Log
 
 ## [1.5.0] - _In Development_
 
+### Changed
+* Upgrade to Guice 5.0.1
+
 ## [1.4.1] - _2019-11-02_
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-  ext.guice_version = '4.2.2'
-  ext.kotlin_version = '1.3.41'
+  ext.guice_version = '5.0.1'
+  ext.kotlin_version = '1.4.32'
 
   repositories {
     jcenter()


### PR DESCRIPTION
This upgrades:

* Guice to 5.0.1
* Kotlin to 1.4.32

Guice 5.0.1 replaces cglib which removes a ton of 'illegal reflective access' warnings that previously came from Guice when running it on newer versions of JVM.