### PR TITLE
Add annotation instance support for KotlinMapBinder

### DIFF
--- a/kotlin-guice/src/main/kotlin/dev/misfitlabs/kotlinguice4/multibindings/KotlinMapBinder.kt
+++ b/kotlin-guice/src/main/kotlin/dev/misfitlabs/kotlinguice4/multibindings/KotlinMapBinder.kt
@@ -76,6 +76,20 @@ interface KotlinMapBinder<K, V> {
                 valueType,
                 Key.get(mapOf(keyType, valueType)))
         }
+        /**
+         * Returns a new mapbinder that collects entries of [K]/[V] in a {@link Map} that is bound
+         * with [annotation].
+         */
+        inline fun <reified K, reified V> newAnnotatedMapBinder(binder: Binder, annotation: Annotation): KotlinMapBinder<K,V> {
+            val keyType = typeLiteral<K>()
+            val valueType = typeLiteral<V>()
+            val mapBinder = MapBinder.newMapBinder(binder, keyType, valueType, annotation)
+            return newRealMapBinder(binder,
+                mapBinder,
+                keyType,
+                valueType,
+                Key.get(mapOf(keyType, valueType), annotation))
+        }
 
         /**
          * Returns a new mapbinder that collects entries of [K]/[V] in a {@link Map} that is bound

--- a/kotlin-guice/src/test/kotlin/dev/misfitlabs/kotlinguice4/multibindings/KotlinMapBinderSpec.kt
+++ b/kotlin-guice/src/test/kotlin/dev/misfitlabs/kotlinguice4/multibindings/KotlinMapBinderSpec.kt
@@ -30,6 +30,7 @@ import com.google.inject.util.Types
 import dev.misfitlabs.kotlinguice4.KotlinModule
 import dev.misfitlabs.kotlinguice4.annotatedKey
 import dev.misfitlabs.kotlinguice4.key
+import dev.misfitlabs.kotlinguice4.typeLiteral
 import java.lang.reflect.Type
 import java.util.concurrent.Callable
 import org.amshove.kluent.shouldBeEmpty
@@ -289,6 +290,22 @@ object KotlinMapBinderSpec : Spek({
                 })
 
                 val map = injector.getInstance(annotatedKey<Map<String, A>, Annotated>())
+                map.size shouldEqual 2
+                map["AImpl"]?.get() shouldEqual "Impl of A"
+                map["B"]?.get() shouldEqual "This is B"
+            }
+
+            it("binds simple types into a named map") {
+                val named = Names.named("A Name")
+                val injector = Guice.createInjector(object : KotlinModule() {
+                    override fun configure() {
+                        val aBinder = KotlinMapBinder
+                            .newAnnotatedMapBinder<String, A>(kotlinBinder, named)
+                        aBinder.addBinding("AImpl").to<AImpl>()
+                        aBinder.addBinding("B").to<B>()
+                    }
+                })
+                val map = injector.getInstance(Key.get(typeLiteral<Map<String, A>>(), named))
                 map.size shouldEqual 2
                 map["AImpl"]?.get() shouldEqual "Impl of A"
                 map["B"]?.get() shouldEqual "This is B"


### PR DESCRIPTION
Similar to https://github.com/misfitlabsdev/kotlin-guice/pull/14,
allow annotation instances in the KotlinMapBinder DSL.
Fixes #20